### PR TITLE
feat: Implement DrawLine for Dreamcast

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -178,11 +178,47 @@ void DrawPixelV(Vector2 position, Color color)
 // Draw a line (using gl lines)
 void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY, Color color)
 {
-    rlBegin(RL_LINES);
+  #if defined(PLATFORM_DREAMCAST)
+    // Dreamcast-specific implementation: Draw a line as a thin rectangle using triangles
+    // Calculate direction vector
+    float dx = (float)(endPosX - startPosX);
+    float dy = (float)(endPosY - startPosY);
+
+    // Calculate length of the line
+    float length = sqrt(dx * dx + dy * dy); // Use sqrt instead of sqrtf
+
+    // Normalize direction vector and calculate perpendicular
+    dx /= length;
+    dy /= length;
+    float px = -dy; // Perpendicular vector for width
+    float py = dx;
+
+    // Set line width
+    float lineWidth = 1.0f; // Adjust width as needed
+    float halfWidth = lineWidth / 2.0f;
+
+    // Define rectangle vertices for the line
+    rlBegin(RL_TRIANGLES);
         rlColor4ub(color.r, color.g, color.b, color.a);
-        rlVertex2f((float)startPosX, (float)startPosY);
-        rlVertex2f((float)endPosX, (float)endPosY);
+
+        // First triangle
+        rlVertex2f(startPosX - px * halfWidth, startPosY - py * halfWidth);
+        rlVertex2f(startPosX + px * halfWidth, startPosY + py * halfWidth);
+        rlVertex2f(endPosX + px * halfWidth, endPosY + py * halfWidth);
+
+        // Second triangle
+        rlVertex2f(startPosX - px * halfWidth, startPosY - py * halfWidth);
+        rlVertex2f(endPosX + px * halfWidth, endPosY + py * halfWidth);
+        rlVertex2f(endPosX - px * halfWidth, endPosY - py * halfWidth);
     rlEnd();
+#else
+  // Default implementation for platforms that support GL_LINES
+  rlBegin(RL_LINES);
+      rlColor4ub(color.r, color.g, color.b, color.a);
+      rlVertex2f((float)startPosX, (float)startPosY);
+      rlVertex2f((float)endPosX, (float)endPosY);
+  rlEnd();
+#endif
 }
 
 // Draw a line (using gl lines)


### PR DESCRIPTION
Trying to use DrawLine() it doesn't work. For example:

```c
#include "raylib.h"

int main(void) {
  const int screenWidth = 640;
  const int screenHeight = 480;
  InitWindow(screenWidth, screenHeight, "lines drawing");
  SetTargetFPS(60);

  while (!WindowShouldClose()) {
    BeginDrawing();
    ClearBackground(RAYWHITE);
    DrawText("some basic line drawing for raylib", 20, 20, 20, DARKGRAY);
    DrawLine(18, 42, screenWidth - 18, 42, BLACK);
    EndDrawing();
  }

  CloseWindow();
  return 0;
}
```

This has the following actual behavior:

### Actual Behavior:

* Flycast: doesn't draw any line. Also crashes after a few seconds.
* Real Hardware: using `dc-tool-ip` I see a loooong list of log messages `Line drawing is currently unsupported`

### Expected Behavior:

* To draw the line without any issues

<img width="640" alt="drawline_fixed" src="https://github.com/user-attachments/assets/c6d7d7bb-7f94-4cad-be31-f6ad8d21e904">

This PR is implementing the following:

- Implement DrawLine() for Dreamcast by simulating lines with a thin rectangle using two triangles, as GL_LINES is unsupported.
- Add math.h to access sqrt function for calculating line length and direction normalization.
- Wrap Dreamcast-specific code to ensure compatibility.

