### PR TITLE
[PSP] Enable depth buffer

### DIFF
--- a/src/platforms/rcore_psp.c
+++ b/src/platforms/rcore_psp.c
@@ -529,7 +529,7 @@ int InitPlatform(void)
         EGL_GREEN_SIZE, 1,
         EGL_BLUE_SIZE, 1,
         EGL_ALPHA_SIZE, 0,
-        EGL_DEPTH_SIZE, 0,
+        EGL_DEPTH_SIZE, 1,
         EGL_NONE
     };
     


### PR DESCRIPTION
This is badly needed for 3D, otherwise occlusion would not work.