### PR TITLE
[PSP] Implement exit callback (closing the game properly via the Home button)

### DIFF
--- a/src/platforms/rcore_psp.c
+++ b/src/platforms/rcore_psp.c
@@ -432,11 +432,10 @@ void PollInputEvents(void)
 //----------------------------------------------------------------------------------
 // Module Internal Functions Definition
 //----------------------------------------------------------------------------------
-int done = 0;
 /* Exit callback */
 int exit_callback(int arg1, int arg2, void *common)
 {
-    done = 1;
+    CORE.Window.shouldClose = true;
     return 0;
 }
 
@@ -660,6 +659,7 @@ int InitPlatform(void)
 void ClosePlatform(void)
 {
     // TODO: De-initialize graphics, inputs and more
+    sceKernelExitGame();
 }
 
 // EOF


### PR DESCRIPTION
This brings parity with Raylib's default WindowShouldClose() method, which would help people make their games cross-platform. 

## Problem
When playing on real hardware, closing the game via the Home button freezes the PSP indefinitely as the console waits for the game to close, but the game doesn't do that. 

This is easily overlooked on emulators since they don't wait for the game to actually close.

## Implementation:
When the player presses the HOME button, the PSP kernel calls the exit callback that reports that the window should close. It does nothing on its own, so **samples at the Raylib4Psp repo should be changed** to use WindowShouldClose() instead of flags.

Additionally, I added sceKernelExitGame() to the ClosePlatform function, to gracefully close the game. 