### PR TITLE
Fast math Dreamcast fixes for rmodels.c

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -511,6 +511,16 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
     rlPopMatrix();
 }
 
+/* The Dreamcast's GCC compiler for SuperH has a bug with -ffast-math enabled
+   which causes the compiler to ICE on the following two functions. This
+   workaround solves the ICE while still using the SH4's fast trig instructions
+   for the math.
+*/
+#if defined(__DREAMCAST__)
+    #include <kos.h>
+    #define sinf(s) fsin(s)
+    #define cosf(s) fcos(s)
+#endif
 // Draw sphere wires
 void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Color color)
 {
@@ -610,6 +620,11 @@ void DrawCylinder(Vector3 position, float radiusTop, float radiusBottom, float h
         rlEnd();
     rlPopMatrix();
 }
+
+#if defined(__DREAMCAST__)
+#   undef sinf
+#   undef cosf
+#endif
 
 // Draw a cylinder with base at startPos and top at endPos
 // NOTE: It could be also used for pyramid and cone


### PR DESCRIPTION
GCC SH has a bug in it which causes the compiler to sometimes ICE and crash upon encountering a bunch of sinf()/cosf() calls within the same function. This happens quite rarely, but rmodels.c had two functions which would trigger the issue.

This meant that raylib would not install as a KOS port with -ffast-math enabled, which should typically always be enabled for performance.

This fix both fixes the compiler ICE issue AND forwards the trig calls into KOS's trig routines so that they are still using the SH4's FSCA fast trig approximation instructions, so there's no performance loss either.

This fix should also not alter the code for any other platforms!