### PR TITLE
Use GL_BGRA for Dreamcast GLdc fast path

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -4051,7 +4051,11 @@ void rlEnableStatePointer(int vertexAttribType, void *buffer)
         case GL_VERTEX_ARRAY: glVertexPointer(3, GL_FLOAT, 0, buffer); break;
         case GL_TEXTURE_COORD_ARRAY: glTexCoordPointer(2, GL_FLOAT, 0, buffer); break;
         case GL_NORMAL_ARRAY: if (buffer != NULL) glNormalPointer(GL_FLOAT, 0, buffer); break;
+        #if defined(__DREAMCAST__)
+        case GL_COLOR_ARRAY: if (buffer != NULL) glColorPointer(GL_BGRA, GL_UNSIGNED_BYTE, 0, buffer); break;
+        #else
         case GL_COLOR_ARRAY: if (buffer != NULL) glColorPointer(4, GL_UNSIGNED_BYTE, 0, buffer); break;
+        #endif
         //case GL_INDEX_ARRAY: if (buffer != NULL) glIndexPointer(GL_SHORT, 0, buffer); break; // Indexed colors
         default: break;
     }


### PR DESCRIPTION
This puts raylib on GLdc's fast path, drastically reducing overhead. Performance improvement: ~40 FPS -> ~59 FPS in example scenes.